### PR TITLE
[TD-476] 유저 앱 통합적으로 광고를 관리할 수 있도록 도메인 및 API 수정

### DIFF
--- a/threedollar-admin/http/popup/popup.http
+++ b/threedollar-admin/http/popup/popup.http
@@ -5,12 +5,15 @@ Content-Type: application/json
 
 {
     "positionType": "SPLASH",
-    "platformType": "AOS",
+    "platformType": "ALL",
     "imageUrl": "https://image.png",
     "linkUrl": "https://link.com",
-    "priority": 10,
+    "title": "광고 제목",
+    "subTitle": "광고 내용\n광고 내용을 입력해주세요",
+    "bgColor": "#ffffff",
+    "fontColor": "#2e2e2e",
     "startDateTime": "2022-01-01T00:00:00",
-    "endDateTime": "2022-01-01T00:00:00"
+    "endDateTime": "2023-01-01T00:00:00"
 }
 
 > {%
@@ -40,9 +43,12 @@ Content-Type: application/json
     "platformType": "AOS",
     "imageUrl": "https://image1.png",
     "linkUrl": "https://link1.com",
-    "priority": 1,
-    "startDateTime": "2022-03-01T00:00:00",
-    "endDateTime": "2022-03-01T00:00:00"
+    "title": "광고 제목",
+    "subTitle": "광고 내용\n광고 내용을 입력해주세요",
+    "bgColor": "#ffffff",
+    "fontColor": "#2e2e2e",
+    "startDateTime": "2022-01-01T00:00:00",
+    "endDateTime": "2023-03-01T00:00:00"
 }
 
 > {%

--- a/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/PopupAdminService.kt
+++ b/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/PopupAdminService.kt
@@ -24,7 +24,8 @@ class PopupAdminService(
     fun updatePopup(popupId: Long, request: UpdatePopupRequest) {
         val popup = findPopupById(popupRepository, popupId)
         request.let {
-            popup.update(it.positionType, it.platformType, it.imageUrl, it.linkUrl, it.priority, it.startDateTime, it.endDateTime)
+            popup.update(it.positionType, it.platformType, it.title, it.subTitle, it.imageUrl,
+                it.linkUrl, it.bgColor, it.fontColor, it.startDateTime, it.endDateTime)
         }
     }
 

--- a/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/request/AddPopupRequest.kt
+++ b/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/request/AddPopupRequest.kt
@@ -8,15 +8,18 @@ import java.time.LocalDateTime
 data class AddPopupRequest(
     val positionType: PopupPositionType,
     val platformType: PopupPlatformType,
+    val title: String?,
+    val subTitle: String?,
     val imageUrl: String,
     val linkUrl: String?,
-    val priority: Int,
+    val bgColor: String?,
+    val fontColor: String?,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime
 ) {
 
     fun toEntity(): Popup {
-        return Popup.newInstance(positionType, platformType, imageUrl, linkUrl, startDateTime, endDateTime, priority)
+        return Popup.newInstance(positionType, platformType, title, subTitle, imageUrl, linkUrl, bgColor, fontColor, startDateTime, endDateTime)
     }
 
 }

--- a/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/request/UpdatePopupRequest.kt
+++ b/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/request/UpdatePopupRequest.kt
@@ -7,9 +7,12 @@ import java.time.LocalDateTime
 data class UpdatePopupRequest(
     val positionType: PopupPositionType,
     val platformType: PopupPlatformType,
+    val title: String?,
+    val subTitle: String?,
     val imageUrl: String,
     val linkUrl: String?,
-    val priority: Int,
+    val bgColor: String?,
+    val fontColor: String?,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime
 )

--- a/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/response/PopupsWithPagingResponse.kt
+++ b/threedollar-admin/src/main/kotlin/com/depromeet/threedollar/admin/service/popup/dto/response/PopupsWithPagingResponse.kt
@@ -25,9 +25,10 @@ data class PopupResponse(
     val popupId: Long,
     val positionType: PopupPositionType,
     val platformType: PopupPlatformType,
+    val title: String?,
+    val subTitle: String?,
     val imageUrl: String,
     val linkUrl: String?,
-    val priority: Int,
     val startDateTime: LocalDateTime,
     val endDateTime: LocalDateTime
 ) {
@@ -38,9 +39,10 @@ data class PopupResponse(
                 popupId = popup.id,
                 positionType = popup.positionType,
                 platformType = popup.platformType,
-                imageUrl = popup.imageUrl,
-                linkUrl = popup.linkUrl,
-                priority = popup.priority,
+                title = popup.detail.title,
+                subTitle = popup.detail.subTitle,
+                imageUrl = popup.detail.imageUrl,
+                linkUrl = popup.detail.linkUrl,
                 startDateTime = popup.startDateTime,
                 endDateTime = popup.endDateTime
             )

--- a/threedollar-admin/src/test/kotlin/com/depromeet/threedollar/admin/controller/HealthControllerTest.kt
+++ b/threedollar-admin/src/test/kotlin/com/depromeet/threedollar/admin/controller/HealthControllerTest.kt
@@ -5,8 +5,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.get
 
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @AutoConfigureMockMvc
@@ -17,8 +16,10 @@ class HealthControllerTest(
 
     @Test
     fun healthCheck() {
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/ping"))
-            .andExpect(MockMvcResultMatchers.status().isOk)
+        mockMvc.get("/ping")
+            .andExpect {
+                status { isOk() }
+            }
     }
 
 }

--- a/threedollar-admin/src/test/kotlin/com/depromeet/threedollar/admin/service/popup/PopupAdminServiceTest.kt
+++ b/threedollar-admin/src/test/kotlin/com/depromeet/threedollar/admin/service/popup/PopupAdminServiceTest.kt
@@ -3,10 +3,7 @@ package com.depromeet.threedollar.admin.service.popup
 import com.depromeet.threedollar.admin.service.popup.dto.request.AddPopupRequest
 import com.depromeet.threedollar.admin.service.popup.dto.request.UpdatePopupRequest
 import com.depromeet.threedollar.common.exception.model.NotFoundException
-import com.depromeet.threedollar.domain.user.domain.popup.Popup
-import com.depromeet.threedollar.domain.user.domain.popup.PopupPlatformType
-import com.depromeet.threedollar.domain.user.domain.popup.PopupPositionType
-import com.depromeet.threedollar.domain.user.domain.popup.PopupRepository
+import com.depromeet.threedollar.domain.user.domain.popup.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
@@ -32,18 +29,24 @@ internal class PopupAdminServiceTest(
         // given
         val positionType = PopupPositionType.SPLASH
         val platformType = PopupPlatformType.IOS
+        val title = "title"
+        val subTitle = "subTitle"
         val imageUrl = "https://image-png"
         val linkUrl = "https://link.com"
-        val priority = 1
+        val bgColor = "#ffffff"
+        val fontColor = "#000000"
         val startDateTime = LocalDateTime.of(2022, 1, 1, 0, 0)
         val endDateTime = LocalDateTime.of(2022, 1, 7, 0, 0)
 
         val request = AddPopupRequest(
             positionType = positionType,
             platformType = platformType,
+            title = title,
+            subTitle = subTitle,
             imageUrl = imageUrl,
             linkUrl = linkUrl,
-            priority = priority,
+            bgColor = bgColor,
+            fontColor = fontColor,
             startDateTime = startDateTime,
             endDateTime = endDateTime
         )
@@ -57,9 +60,12 @@ internal class PopupAdminServiceTest(
         popups[0].let {
             assertThat(it.positionType).isEqualTo(positionType)
             assertThat(it.platformType).isEqualTo(platformType)
-            assertThat(it.imageUrl).isEqualTo(imageUrl)
-            assertThat(it.linkUrl).isEqualTo(linkUrl)
-            assertThat(it.priority).isEqualTo(priority)
+            assertThat(it.detail.title).isEqualTo(title)
+            assertThat(it.detail.subTitle).isEqualTo(subTitle)
+            assertThat(it.detail.imageUrl).isEqualTo(imageUrl)
+            assertThat(it.detail.linkUrl).isEqualTo(linkUrl)
+            assertThat(it.detail.bgColor).isEqualTo(bgColor)
+            assertThat(it.detail.fontColor).isEqualTo(fontColor)
             assertThat(it.startDateTime).isEqualTo(startDateTime)
             assertThat(it.endDateTime).isEqualTo(endDateTime)
         }
@@ -73,18 +79,24 @@ internal class PopupAdminServiceTest(
 
         val positionType = PopupPositionType.SPLASH
         val platformType = PopupPlatformType.IOS
+        val title = "title"
+        val subTitle = "subTitle"
         val imageUrl = "https://image-png"
         val linkUrl = "https://link.com"
-        val priority = 1
+        val bgColor = "#ffffff"
+        val fontColor = "#000000"
         val startDateTime = LocalDateTime.of(2022, 1, 1, 0, 0)
         val endDateTime = LocalDateTime.of(2022, 1, 7, 0, 0)
 
         val request = UpdatePopupRequest(
             positionType = positionType,
             platformType = platformType,
+            title = title,
+            subTitle = subTitle,
             imageUrl = imageUrl,
             linkUrl = linkUrl,
-            priority = priority,
+            bgColor = bgColor,
+            fontColor = fontColor,
             startDateTime = startDateTime,
             endDateTime = endDateTime
         )
@@ -98,9 +110,12 @@ internal class PopupAdminServiceTest(
         popups[0].let {
             assertThat(it.positionType).isEqualTo(positionType)
             assertThat(it.platformType).isEqualTo(platformType)
-            assertThat(it.imageUrl).isEqualTo(imageUrl)
-            assertThat(it.linkUrl).isEqualTo(linkUrl)
-            assertThat(it.priority).isEqualTo(priority)
+            assertThat(it.detail.title).isEqualTo(title)
+            assertThat(it.detail.subTitle).isEqualTo(subTitle)
+            assertThat(it.detail.imageUrl).isEqualTo(imageUrl)
+            assertThat(it.detail.linkUrl).isEqualTo(linkUrl)
+            assertThat(it.detail.bgColor).isEqualTo(bgColor)
+            assertThat(it.detail.fontColor).isEqualTo(fontColor)
             assertThat(it.startDateTime).isEqualTo(startDateTime)
             assertThat(it.endDateTime).isEqualTo(endDateTime)
         }
@@ -112,9 +127,12 @@ internal class PopupAdminServiceTest(
         val request = UpdatePopupRequest(
             positionType = PopupPositionType.SPLASH,
             platformType = PopupPlatformType.AOS,
+            title = "title",
+            subTitle = "",
             imageUrl = "imageUrl",
             linkUrl = "linkUrl",
-            priority = 10,
+            bgColor = "#ffffff",
+            fontColor = "#000000",
             startDateTime = LocalDateTime.of(2022, 1, 1, 0, 0),
             endDateTime = LocalDateTime.of(2022, 1, 3, 0, 0),
         )
@@ -144,14 +162,17 @@ internal class PopupAdminServiceTest(
     }
 
     private fun createPopup(): Popup {
-        return Popup.newInstance(
+        return PopupCreator.create(
             PopupPositionType.SPLASH,
             PopupPlatformType.AOS,
+            "제목",
+            "서브 타이틀",
             "imageUrl",
             "linkUrl",
+            "#ffffff",
+            "#000000",
             LocalDateTime.of(2022, 3, 1, 0, 0),
-            LocalDateTime.of(2022, 3, 7, 0, 0),
-            10)
+            LocalDateTime.of(2022, 3, 7, 0, 0))
     }
 
 }

--- a/threedollar-api-core/src/main/java/com/depromeet/threedollar/application/service/popup/PopupService.kt
+++ b/threedollar-api-core/src/main/java/com/depromeet/threedollar/application/service/popup/PopupService.kt
@@ -18,8 +18,8 @@ class PopupService(
     @Transactional(readOnly = true)
     fun getActivatedPopups(request: GetActivatedPopupsRequest): List<PopupResponse> {
         return popupRepository.findActivatedPopupsByPositionAndPlatform(request.position, request.platform, LocalDateTime.now()).asSequence()
-            .sortedBy { it.priority }
-            .map { PopupResponse.of(it) }
+            .map { PopupResponse.of(it.detail) }
+            .shuffled()
             .toList()
     }
 

--- a/threedollar-api-core/src/main/java/com/depromeet/threedollar/application/service/popup/dto/response/PopupResponse.kt
+++ b/threedollar-api-core/src/main/java/com/depromeet/threedollar/application/service/popup/dto/response/PopupResponse.kt
@@ -1,15 +1,26 @@
 package com.depromeet.threedollar.application.service.popup.dto.response
 
-import com.depromeet.threedollar.domain.user.domain.popup.Popup
+import com.depromeet.threedollar.domain.user.domain.popup.PopupDetail
 
 data class PopupResponse(
+    val title: String?,
+    val subTitle: String?,
     val imageUrl: String,
-    val linkUrl: String
+    val linkUrl: String?,
+    val bgColor: String?,
+    val fontColor: String?
 ) {
 
     companion object {
-        fun of(popup: Popup): PopupResponse {
-            return PopupResponse(popup.imageUrl, popup.linkUrl)
+        fun of(popup: PopupDetail): PopupResponse {
+            return PopupResponse(
+                title = popup.title,
+                subTitle = popup.subTitle,
+                imageUrl = popup.imageUrl,
+                linkUrl = popup.linkUrl,
+                bgColor = popup.bgColor,
+                fontColor = popup.fontColor
+            )
         }
     }
 

--- a/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/store/StoreMenuControllerTest.java
+++ b/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/store/StoreMenuControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -38,12 +37,9 @@ class StoreMenuControllerTest {
     @DisplayName("GET /api/v2/store/menu/categories")
     @Test
     void 활성화된_메뉴_카테고리의_정보들을_조회한다() throws Exception {
-        // given
-        MockHttpServletRequestBuilder builder = get("/api/v2/store/menu/categories");
-
-        // when
+        // when & then
         ApiResponse<List<MenuCategoryResponse>> response = objectMapper.readValue(
-            mockMvc.perform(builder)
+            mockMvc.perform(get("/api/v2/store/menu/categories"))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andReturn()

--- a/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/storeimage/StoreImageMockApiCaller.java
+++ b/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/storeimage/StoreImageMockApiCaller.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -24,11 +23,9 @@ class StoreImageMockApiCaller extends MockMvcUtils {
     }
 
     ApiResponse<List<StoreImageResponse>> getStoreImages(Long storeId, int expectedStatus) throws Exception {
-        MockHttpServletRequestBuilder builder = get("/api/v2/store/" + storeId + "/images")
-            .param("storeId", String.valueOf(storeId));
-
         return objectMapper.readValue(
-            mockMvc.perform(builder)
+            mockMvc.perform(get("/api/v2/store/" + storeId + "/images")
+                .param("storeId", String.valueOf(storeId)))
                 .andExpect(status().is(expectedStatus))
                 .andDo(print())
                 .andReturn()
@@ -39,11 +36,9 @@ class StoreImageMockApiCaller extends MockMvcUtils {
     }
 
     ApiResponse<String> deleteStoreImage(Long imageId, String token, int expectedStatus) throws Exception {
-        MockHttpServletRequestBuilder builder = delete("/api/v2/store/image/".concat(String.valueOf(imageId)))
-            .header(HttpHeaders.AUTHORIZATION, token);
-
         return objectMapper.readValue(
-            mockMvc.perform(builder)
+            mockMvc.perform(delete("/api/v2/store/image/".concat(String.valueOf(imageId)))
+                .header(HttpHeaders.AUTHORIZATION, token))
                 .andExpect(status().is(expectedStatus))
                 .andDo(print())
                 .andReturn()

--- a/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/user/UserMockApiCaller.java
+++ b/threedollar-api-user/src/test/java/com/depromeet/threedollar/api/controller/user/UserMockApiCaller.java
@@ -6,7 +6,6 @@ import com.depromeet.threedollar.application.common.dto.ApiResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.nio.charset.StandardCharsets;
 
@@ -20,10 +19,8 @@ public class UserMockApiCaller extends MockMvcUtils {
     }
 
     public ApiResponse<LoginResponse> getTestToken() throws Exception {
-        MockHttpServletRequestBuilder builder = get("/test-token");
-
         return objectMapper.readValue(
-            mockMvc.perform(builder)
+            mockMvc.perform(get("/test-token"))
                 .andDo(print())
                 .andReturn()
                 .getResponse()

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/Popup.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/Popup.java
@@ -34,51 +34,44 @@ public class Popup extends AuditingTimeEntity {
     @Enumerated(EnumType.STRING)
     private PopupPlatformType platformType;
 
-    @Column(nullable = false, length = 2048)
-    private String imageUrl;
-
-    @Column(length = 2048)
-    private String linkUrl;
-
-    @Column(nullable = false)
-    private int priority;
-
     @Embedded
     private DateTimeInterval dateTimeInterval;
 
+    @Embedded
+    private PopupDetail detail;
+
     @Builder(access = AccessLevel.PACKAGE)
-    private Popup(PopupPositionType positionType, PopupPlatformType platformType, String imageUrl, String linkUrl,
-                  LocalDateTime startDateTime, LocalDateTime endDateTime, int priority) {
+    private Popup(PopupPositionType positionType, PopupPlatformType platformType, @Nullable String title, @Nullable String subTitle,
+                  String imageUrl, String linkUrl, @Nullable String bgColor, @Nullable String fontColor, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         this.positionType = positionType;
         this.platformType = platformType;
-        this.imageUrl = imageUrl;
-        this.linkUrl = linkUrl;
         this.dateTimeInterval = DateTimeInterval.of(startDateTime, endDateTime);
-        this.priority = priority;
+        this.detail = PopupDetail.of(title, subTitle, imageUrl, linkUrl, bgColor, fontColor);
     }
 
-    public static Popup newInstance(PopupPositionType positionType, PopupPlatformType platformType, String imageUrl, String linkUrl,
-                                    LocalDateTime startDateTime, LocalDateTime endDateTime, int priority) {
+    public static Popup newInstance(PopupPositionType positionType, PopupPlatformType platformType, @Nullable String title,
+                                    @Nullable String subTitle, @Nullable String imageUrl, @Nullable String linkUrl,
+                                    @Nullable String bgColor, @Nullable String fontColor, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return Popup.builder()
             .positionType(positionType)
             .platformType(platformType)
-            .imageUrl(imageUrl)
-            .linkUrl(linkUrl)
             .startDateTime(startDateTime)
             .endDateTime(endDateTime)
-            .priority(priority)
+            .title(title)
+            .subTitle(subTitle)
+            .bgColor(bgColor)
+            .fontColor(fontColor)
+            .imageUrl(imageUrl)
+            .linkUrl(linkUrl)
             .build();
     }
 
-    public void update(@NotNull PopupPositionType positionType, @NotNull PopupPlatformType platformType,
-                       @NotNull String imageUrl, @Nullable String linkUrl, int priority,
-                       @NotNull LocalDateTime startDateTime, @NotNull LocalDateTime endDateTime) {
+    public void update(PopupPositionType positionType, PopupPlatformType platformType, @Nullable String title, @Nullable String subTitle,
+                       String imageUrl, @Nullable String linkUrl, @Nullable String bgColor, @Nullable String fontColor, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         this.positionType = positionType;
         this.platformType = platformType;
-        this.imageUrl = imageUrl;
-        this.linkUrl = linkUrl;
-        this.priority = priority;
         this.dateTimeInterval = DateTimeInterval.of(startDateTime, endDateTime);
+        this.detail = PopupDetail.of(title, subTitle, imageUrl, linkUrl, bgColor, fontColor);
     }
 
     @NotNull

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupCreator.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupCreator.java
@@ -3,6 +3,7 @@ package com.depromeet.threedollar.domain.user.domain.popup;
 import com.depromeet.threedollar.common.docs.ObjectMother;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDateTime;
 
@@ -10,12 +11,18 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PopupCreator {
 
-    public static Popup create(PopupPositionType popupPositionType, PopupPlatformType platformType, String imageUrl, String linkUrl, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public static Popup create(PopupPositionType popupPositionType, PopupPlatformType platformType, @Nullable String title,
+                               @Nullable String subTitle, String imageUrl, @Nullable String linkUrl, @Nullable String bgColor, @Nullable String fontColor,
+                               LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return Popup.builder()
+            .title(title)
+            .subTitle(subTitle)
             .positionType(popupPositionType)
             .platformType(platformType)
             .imageUrl(imageUrl)
             .linkUrl(linkUrl)
+            .bgColor(bgColor)
+            .fontColor(fontColor)
             .startDateTime(startDateTime)
             .endDateTime(endDateTime)
             .build();

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupDetail.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupDetail.java
@@ -1,0 +1,53 @@
+package com.depromeet.threedollar.domain.user.domain.popup;
+
+import lombok.*;
+import org.jetbrains.annotations.Nullable;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class PopupDetail {
+
+    @Column(length = 50)
+    private String title;
+
+    @Column(length = 100)
+    private String subTitle;
+
+    @Column(nullable = false, length = 2048)
+    private String imageUrl;
+
+    @Column(length = 2048)
+    private String linkUrl;
+
+    @Column(length = 7)
+    private String bgColor;
+
+    @Column(length = 7)
+    private String fontColor;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PopupDetail(String title, String subTitle, String imageUrl, String linkUrl, String bgColor, String fontColor) {
+        this.title = title;
+        this.subTitle = subTitle;
+        this.imageUrl = imageUrl;
+        this.linkUrl = linkUrl;
+        this.bgColor = bgColor;
+        this.fontColor = fontColor;
+    }
+
+    public static PopupDetail of(@Nullable String title, @Nullable String subTitle, String imageUrl, @Nullable String linkUrl, @Nullable String bgColor, @Nullable String fontColor) {
+        return PopupDetail.builder()
+            .title(title)
+            .subTitle(subTitle)
+            .imageUrl(imageUrl)
+            .linkUrl(linkUrl)
+            .bgColor(bgColor)
+            .fontColor(fontColor)
+            .build();
+    }
+
+}

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupPlatformType.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupPlatformType.java
@@ -11,6 +11,7 @@ public enum PopupPlatformType implements EnumModel {
 
     AOS("안드로이드"),
     IOS("iOS"),
+    ALL("모든 플랫폼"),
     ;
 
     private final String description;

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupPositionType.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/PopupPositionType.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum PopupPositionType implements EnumModel {
 
     SPLASH("스플래시"),
+    MAIN_PAGE_CARD("메인 페이지 가게 카드"),
+    STORE_CATEGORY_LIST("가게 카테고리"),
+    MENU_CATEGORY_BANNER("메뉴 카테고리 배너"),
     ;
 
     private final String description;

--- a/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/repository/PopupRepositoryCustomImpl.java
+++ b/threedollar-domain/src/main/java/com/depromeet/threedollar/domain/user/domain/popup/repository/PopupRepositoryCustomImpl.java
@@ -21,7 +21,7 @@ public class PopupRepositoryCustomImpl implements PopupRepositoryCustom {
         return queryFactory.selectFrom(popup)
             .where(
                 popup.positionType.eq(positionType),
-                popup.platformType.eq(platformType),
+                popup.platformType.in(platformType, PopupPlatformType.ALL),
                 popup.dateTimeInterval.startDateTime.loe(dateTime),
                 popup.dateTimeInterval.endDateTime.goe(dateTime)
             )

--- a/threedollar-domain/src/main/resources/db/migration/V21__update_popup.sql
+++ b/threedollar-domain/src/main/resources/db/migration/V21__update_popup.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `popup`
+    ADD COLUMN `title` VARCHAR(50) DEFAULT NULL;
+
+ALTER TABLE `popup`
+    ADD COLUMN `sub_title` VARCHAR(100) DEFAULT NULL;
+
+ALTER TABLE `popup`
+    ADD COLUMN `bg_color` CHAR(7) DEFAULT NULL;
+
+ALTER TABLE `popup`
+    ADD COLUMN `font_color` CHAR(7) DEFAULT NULL;
+
+ALTER TABLE `popup`
+    DROP `priority`;

--- a/threedollar-domain/src/test/java/com/depromeet/threedollar/domain/user/domain/popup/PopupRepositoryTest.java
+++ b/threedollar-domain/src/test/java/com/depromeet/threedollar/domain/user/domain/popup/PopupRepositoryTest.java
@@ -27,12 +27,16 @@ class PopupRepositoryTest {
         // given
         PopupPositionType positionType = PopupPositionType.SPLASH;
         PopupPlatformType platformType = PopupPlatformType.AOS;
+        String title = "광고 제목";
+        String subTitle = "광고 내용\n광고 내용";
         LocalDateTime startDateTime = LocalDateTime.of(2021, 11, 25, 0, 0);
         LocalDateTime endDateTime = LocalDateTime.of(2021, 11, 26, 0, 0);
         String imageUrl = "https://image.url";
         String linkUrl = "https://link.com";
+        String bgColor = "#ffffff";
+        String fontColor = "#000000";
 
-        popupRepository.save(PopupCreator.create(positionType, platformType, imageUrl, linkUrl, startDateTime, endDateTime));
+        popupRepository.save(PopupCreator.create(positionType, platformType, title, subTitle, imageUrl, linkUrl, bgColor, fontColor, startDateTime, endDateTime));
 
         // when
         List<Popup> findPopups = popupRepository.findActivatedPopupsByPositionAndPlatform(positionType, platformType, startDateTime.plusMinutes(1));
@@ -40,8 +44,12 @@ class PopupRepositoryTest {
         // then
         assertAll(
             () -> assertThat(findPopups).hasSize(1),
-            () -> assertThat(findPopups.get(0).getImageUrl()).isEqualTo(imageUrl),
-            () -> assertThat(findPopups.get(0).getLinkUrl()).isEqualTo(linkUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getTitle()).isEqualTo(title),
+            () -> assertThat(findPopups.get(0).getDetail().getSubTitle()).isEqualTo(subTitle),
+            () -> assertThat(findPopups.get(0).getDetail().getImageUrl()).isEqualTo(imageUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getLinkUrl()).isEqualTo(linkUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getBgColor()).isEqualTo(bgColor),
+            () -> assertThat(findPopups.get(0).getDetail().getFontColor()).isEqualTo(fontColor),
             () -> assertThat(findPopups.get(0).getStartDateTime()).isEqualTo(startDateTime),
             () -> assertThat(findPopups.get(0).getEndDateTime()).isEqualTo(endDateTime),
             () -> assertThat(findPopups.get(0).getPlatformType()).isEqualTo(platformType)
@@ -53,12 +61,16 @@ class PopupRepositoryTest {
         // given
         PopupPositionType positionType = PopupPositionType.SPLASH;
         PopupPlatformType platformType = PopupPlatformType.IOS;
+        String title = "광고 제목";
+        String subTitle = "광고 내용\n광고 내용";
         LocalDateTime startDateTime = LocalDateTime.of(2021, 11, 24, 0, 0);
         LocalDateTime endDateTime = LocalDateTime.of(2021, 11, 25, 0, 0);
         String imageUrl = "https://image.url";
         String linkUrl = "https://link.com";
+        String bgColor = "#ffffff";
+        String fontColor = "#000000";
 
-        popupRepository.save(PopupCreator.create(positionType, platformType, imageUrl, linkUrl, startDateTime, endDateTime));
+        popupRepository.save(PopupCreator.create(positionType, platformType, title, subTitle, imageUrl, linkUrl, bgColor, fontColor, startDateTime, endDateTime));
 
         // when
         List<Popup> findPopups = popupRepository.findActivatedPopupsByPositionAndPlatform(positionType, platformType, endDateTime.minusMinutes(1));
@@ -66,8 +78,12 @@ class PopupRepositoryTest {
         // then
         assertAll(
             () -> assertThat(findPopups).hasSize(1),
-            () -> assertThat(findPopups.get(0).getImageUrl()).isEqualTo(imageUrl),
-            () -> assertThat(findPopups.get(0).getLinkUrl()).isEqualTo(linkUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getTitle()).isEqualTo(title),
+            () -> assertThat(findPopups.get(0).getDetail().getSubTitle()).isEqualTo(subTitle),
+            () -> assertThat(findPopups.get(0).getDetail().getImageUrl()).isEqualTo(imageUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getLinkUrl()).isEqualTo(linkUrl),
+            () -> assertThat(findPopups.get(0).getDetail().getBgColor()).isEqualTo(bgColor),
+            () -> assertThat(findPopups.get(0).getDetail().getFontColor()).isEqualTo(fontColor),
             () -> assertThat(findPopups.get(0).getStartDateTime()).isEqualTo(startDateTime),
             () -> assertThat(findPopups.get(0).getEndDateTime()).isEqualTo(endDateTime),
             () -> assertThat(findPopups.get(0).getPlatformType()).isEqualTo(platformType)


### PR DESCRIPTION
## 변경사항

- 유저 서버 광고 API 수정 (플랫폼/위치 별로 광고 조회)
- 관리자 서버 광고 API 수정 (광고 CRUD)
- 도메인 및 DDL 수정

- 기존 스플래시 팝업으로 사용되는 API 및 도메인을 유저 앱의 전체 광고를 관리하는 용도로 사용하도록 수정
- 각 위치의 광고마다 스키마가 일정하지 않는 이슈가 있는데, 차후 MonogoDB로 마이그레이션 해서 유동적으로 대응할 수 있도록 할 예정
