### PR TITLE
[TD-586] 사장님 가게에 피드백 등록 및 전체 피드백의 갯수를 조회하는 기능 추가

### DIFF
--- a/threedollar-api-boss/http/feedback/feedback.http
+++ b/threedollar-api-boss/http/feedback/feedback.http
@@ -1,0 +1,2 @@
+### 특정 사장님의 가게의 피드백을 조회합니다
+GET {{host_boss_api}}/v1/boss-store/feedback/{{BOSS_STORE_ID}}

--- a/threedollar-api-boss/http/mock.http
+++ b/threedollar-api-boss/http/mock.http
@@ -14,3 +14,7 @@ Authorization: Bearer {{BOSS_AUTHORIZATION}}
 > {%
 client.global.set("BOSS_STORE_ID", response.body["data"])
 %}
+
+
+### [테스트용] 가게에 피드백을 추가합니다
+GET {{host_boss_api}}/test-feedback/{{BOSS_STORE_ID}}?feedbackType=FOOD_IS_DELICIOUS&date=2022-02-16

--- a/threedollar-api-boss/src/integrationTest/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackServiceTest.kt
+++ b/threedollar-api-boss/src/integrationTest/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackServiceTest.kt
@@ -1,0 +1,160 @@
+package com.depromeet.threedollar.boss.api.service.feedback
+
+import com.depromeet.threedollar.boss.api.service.feedback.dto.request.AddBossStoreFeedbackRequest
+import com.depromeet.threedollar.common.exception.model.ConflictException
+import com.depromeet.threedollar.common.exception.model.NotFoundException
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedback
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackCreator
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackRepository
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackType
+import com.depromeet.threedollar.document.boss.document.store.BossStoreCreator
+import com.depromeet.threedollar.document.boss.document.store.BossStoreRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertAll
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import java.time.LocalDate
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest
+internal class BossStoreFeedbackServiceTest(
+    private val bossStoreFeedbackRepository: BossStoreFeedbackRepository,
+    private val bossStoreRepository: BossStoreRepository,
+    private val bossStoreFeedbackService: BossStoreFeedbackService
+) {
+
+    @AfterEach
+    fun cleanUp() {
+        bossStoreRepository.deleteAll()
+        bossStoreFeedbackRepository.deleteAll()
+    }
+
+    @Test
+    fun `가게에 피드백을 등록한다`() {
+        // given
+        val feedbackType = BossStoreFeedbackType.BOSS_IS_KIND
+        val userId = 1000000L
+        val date = LocalDate.of(2022, 2, 24)
+
+        val bossStore = BossStoreCreator.create(
+            bossId = "bossId",
+            name = "가슴속 3천원 붕어빵 가게"
+        )
+        bossStoreRepository.save(bossStore)
+
+        // when
+        bossStoreFeedbackService.addFeedback(
+            bossStoreId = bossStore.id,
+            request = AddBossStoreFeedbackRequest(feedbackType),
+            userId = userId,
+            date = date
+        )
+
+        // then
+        val bossStoreFeedbacks = bossStoreFeedbackRepository.findAll()
+        assertAll({
+            assertThat(bossStoreFeedbacks).hasSize(1)
+            assertThat(bossStoreFeedbacks[0].storeId).isEqualTo(bossStore.id)
+            assertThat(bossStoreFeedbacks[0].userId).isEqualTo(userId)
+            assertThat(bossStoreFeedbacks[0].date).isEqualTo(date)
+            assertThat(bossStoreFeedbacks[0].feedbackType).isEqualTo(feedbackType)
+        })
+    }
+
+    @Test
+    fun `피드백을 추가하려는 가게가 존재하지 않는 경우 NotFoundException`() {
+        // when & then
+        assertThatThrownBy {
+            bossStoreFeedbackService.addFeedback(
+                bossStoreId = "NotFound BossStore Id",
+                request = AddBossStoreFeedbackRequest(BossStoreFeedbackType.BOSS_IS_KIND),
+                userId = 1000L,
+                date = LocalDate.of(2022, 2, 24)
+            )
+        }.isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `해당 사용자가 오늘 이미 피드백을 등록한 가게면 ConflictException이 발생한다`() {
+        // given
+        val feedbackType = BossStoreFeedbackType.FOOD_IS_DELICIOUS
+        val userId = 1000000L
+        val date = LocalDate.of(2022, 2, 24)
+
+        val bossStore = BossStoreCreator.create(
+            bossId = "bossId",
+            name = "가슴속 3천원 붕어빵 가게"
+        )
+        bossStoreRepository.save(bossStore)
+
+        bossStoreFeedbackRepository.save(BossStoreFeedbackCreator.create(
+            storeId = bossStore.id,
+            userId = userId,
+            date = date,
+            feedbackType = BossStoreFeedbackType.PLATING_IS_BEAUTIFUL
+        ))
+
+        // when & then
+        assertThatThrownBy {
+            bossStoreFeedbackService.addFeedback(
+                bossStoreId = bossStore.id,
+                request = AddBossStoreFeedbackRequest(feedbackType),
+                userId = userId,
+                date = date
+            )
+        }.isInstanceOf(ConflictException::class.java)
+    }
+
+    @Test
+    fun `다른날 가게에 피드백을 추가했다면 피드백을 추가할 수 있다`() {
+        // given
+        val feedbackType = BossStoreFeedbackType.FOOD_IS_DELICIOUS
+        val userId = 1000000L
+        val date = LocalDate.of(2022, 2, 24)
+
+        val bossStore = BossStoreCreator.create(
+            bossId = "bossId",
+            name = "가슴속 3천원 붕어빵 가게"
+        )
+        bossStoreRepository.save(bossStore)
+
+        bossStoreFeedbackRepository.save(BossStoreFeedbackCreator.create(
+            storeId = bossStore.id,
+            userId = userId,
+            date = LocalDate.of(2022, 2, 23),
+            feedbackType = BossStoreFeedbackType.PLATING_IS_BEAUTIFUL
+        ))
+
+        // when
+        bossStoreFeedbackService.addFeedback(
+            bossStoreId = bossStore.id,
+            request = AddBossStoreFeedbackRequest(feedbackType),
+            userId = userId,
+            date = date
+        )
+
+        // then
+        val bossStoreFeedbacks = bossStoreFeedbackRepository.findAll()
+        assertAll({
+            assertThat(bossStoreFeedbacks).hasSize(2)
+            bossStoreFeedbacks[0].let {
+                assertThat(it.storeId).isEqualTo(bossStore.id)
+                assertThat(it.userId).isEqualTo(userId)
+                assertThat(it.date).isEqualTo(LocalDate.of(2022, 2, 23))
+                assertThat(it.feedbackType).isEqualTo(BossStoreFeedbackType.PLATING_IS_BEAUTIFUL)
+            }
+
+            bossStoreFeedbacks[1].let {
+                assertThat(it.storeId).isEqualTo(bossStore.id)
+                assertThat(it.userId).isEqualTo(userId)
+                assertThat(it.date).isEqualTo(date)
+                assertThat(it.feedbackType).isEqualTo(feedbackType)
+            }
+        })
+    }
+
+}

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/controller/LocalTestController.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/controller/LocalTestController.kt
@@ -6,11 +6,14 @@ import com.depromeet.threedollar.boss.api.config.resolver.BossId
 import com.depromeet.threedollar.boss.api.config.session.SessionConstants
 import com.depromeet.threedollar.boss.api.service.auth.dto.response.LoginResponse
 import com.depromeet.threedollar.boss.api.service.category.BossStoreCategoryServiceUtils
+import com.depromeet.threedollar.boss.api.service.feedback.BossStoreFeedbackService
+import com.depromeet.threedollar.boss.api.service.feedback.dto.request.AddBossStoreFeedbackRequest
 import com.depromeet.threedollar.common.exception.model.InternalServerException
 import com.depromeet.threedollar.common.type.DayOfTheWeek
 import com.depromeet.threedollar.document.boss.document.account.*
 import com.depromeet.threedollar.document.boss.document.category.BossStoreCategory
 import com.depromeet.threedollar.document.boss.document.category.BossStoreCategoryRepository
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackType
 import com.depromeet.threedollar.document.boss.document.store.*
 import com.depromeet.threedollar.document.common.document.BusinessNumber
 import com.depromeet.threedollar.document.common.document.ContactsNumber
@@ -18,9 +21,11 @@ import com.depromeet.threedollar.document.common.document.TimeInterval
 import io.swagger.annotations.ApiOperation
 import org.springframework.data.geo.Point
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 import java.time.LocalTime
 import javax.servlet.http.HttpSession
 
@@ -30,6 +35,7 @@ class LocalTestController(
     private val bossStoreRepository: BossStoreRepository,
     private val bossStoreCategoryRepository: BossStoreCategoryRepository,
     private val bossStoreLocationRepository: BossStoreLocationRepository,
+    private val bossStoreFeedbackService: BossStoreFeedbackService,
     private val httpSession: HttpSession
 ) {
 
@@ -138,6 +144,16 @@ class LocalTestController(
             businessNumber = BusinessNumber.of("000-12-12345"),
             pushSettingsStatus = PushSettingsStatus.OFF
         )
+    }
+
+    @ApiOperation("[개발 서버용] 가게에 피드백을 추가합니다")
+    @GetMapping("/test-feedback/{bossStoreId}")
+    fun addTestFeedback(
+        @PathVariable bossStoreId: String,
+        @RequestParam feedbackType: BossStoreFeedbackType,
+        @RequestParam date: LocalDate
+    ) {
+        bossStoreFeedbackService.addFeedback(bossStoreId, AddBossStoreFeedbackRequest(feedbackType), 0L, date)
     }
 
 }

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/controller/feedback/BossStoreFeedbackController.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/controller/feedback/BossStoreFeedbackController.kt
@@ -1,0 +1,23 @@
+package com.depromeet.threedollar.boss.api.controller.feedback
+
+import com.depromeet.threedollar.application.common.dto.ApiResponse
+import com.depromeet.threedollar.boss.api.service.feedback.BossStoreFeedbackService
+import io.swagger.annotations.ApiOperation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class BossStoreFeedbackController(
+    private val bossStoreFeedbackService: BossStoreFeedbackService
+) {
+
+    @ApiOperation("특정 사장님의 가게의 피드백을 조회합니다.")
+    @GetMapping("/v1/boss-store/feedback/{bossStoreId}")
+    fun getBossStoreFeedbacks(
+        @PathVariable bossStoreId: String
+    ): ApiResponse<Map<String, Long>> {
+        return ApiResponse.success(bossStoreFeedbackService.retrieveBossStoreFeedbacks(bossStoreId))
+    }
+
+}

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/redis/BossStoreFeedbackCounter.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/redis/BossStoreFeedbackCounter.kt
@@ -1,0 +1,28 @@
+package com.depromeet.threedollar.boss.api.redis
+
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackType
+import org.springframework.data.redis.core.HashOperations
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.util.Objects
+
+@Repository
+class BossStoreFeedbackCounter(
+    private val redisTemplate: RedisTemplate<String, Objects>
+) {
+
+    fun increment(bossStoreId: String, feedbackType: BossStoreFeedbackType) {
+        val counter: HashOperations<String, String, Long> = redisTemplate.opsForHash()
+        counter.increment(getKey(bossStoreId), feedbackType.name, 1)
+    }
+
+    fun getAllCounts(bossStoreId: String): Map<String, Long> {
+        val counter: HashOperations<String, String, Long> = redisTemplate.opsForHash()
+        return counter.entries(getKey(bossStoreId))
+    }
+
+    private fun getKey(bossStoreId: String): String {
+        return "boss:store:feedback:${bossStoreId}"
+    }
+
+}

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackService.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackService.kt
@@ -1,0 +1,32 @@
+package com.depromeet.threedollar.boss.api.service.feedback
+
+import com.depromeet.threedollar.boss.api.service.feedback.dto.request.AddBossStoreFeedbackRequest
+import com.depromeet.threedollar.boss.api.service.store.BossStoreServiceUtils
+import com.depromeet.threedollar.common.exception.model.ConflictException
+import com.depromeet.threedollar.common.exception.type.ErrorCode
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackRepository
+import com.depromeet.threedollar.document.boss.document.store.BossStoreRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class BossStoreFeedbackService(
+    private val bossStoreRepository: BossStoreRepository,
+    private val bossStoreFeedbackRepository: BossStoreFeedbackRepository
+) {
+
+    @Transactional
+    fun addFeedback(bossStoreId: String, request: AddBossStoreFeedbackRequest, userId: Long, date: LocalDate) {
+        BossStoreServiceUtils.validateExistsBossStore(bossStoreRepository, bossStoreId)
+        validateNotExistsFeedbackToday(storeId = bossStoreId, userId = userId, date = date)
+        bossStoreFeedbackRepository.save(request.toDocument(bossStoreId, userId, date))
+    }
+
+    private fun validateNotExistsFeedbackToday(storeId: String, userId: Long, date: LocalDate) {
+        if (bossStoreFeedbackRepository.existsByStoreIdAndUserIdAndDate(storeId, userId, date)) {
+            throw ConflictException("해당 날짜($date)에 유저($userId)는 해당 가게($storeId)에 이미 피드백을 추가하였습니다", ErrorCode.CONFLICT)
+        }
+    }
+
+}

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackService.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/BossStoreFeedbackService.kt
@@ -1,11 +1,13 @@
 package com.depromeet.threedollar.boss.api.service.feedback
 
+import com.depromeet.threedollar.boss.api.redis.BossStoreFeedbackCounter
 import com.depromeet.threedollar.boss.api.service.feedback.dto.request.AddBossStoreFeedbackRequest
 import com.depromeet.threedollar.boss.api.service.store.BossStoreServiceUtils
 import com.depromeet.threedollar.common.exception.model.ConflictException
 import com.depromeet.threedollar.common.exception.type.ErrorCode
 import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackRepository
 import com.depromeet.threedollar.document.boss.document.store.BossStoreRepository
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -13,7 +15,8 @@ import java.time.LocalDate
 @Service
 class BossStoreFeedbackService(
     private val bossStoreRepository: BossStoreRepository,
-    private val bossStoreFeedbackRepository: BossStoreFeedbackRepository
+    private val bossStoreFeedbackRepository: BossStoreFeedbackRepository,
+    private val bossStoreFeedbackCounter: BossStoreFeedbackCounter
 ) {
 
     @Transactional
@@ -21,12 +24,25 @@ class BossStoreFeedbackService(
         BossStoreServiceUtils.validateExistsBossStore(bossStoreRepository, bossStoreId)
         validateNotExistsFeedbackToday(storeId = bossStoreId, userId = userId, date = date)
         bossStoreFeedbackRepository.save(request.toDocument(bossStoreId, userId, date))
+        bossStoreFeedbackCounter.increment(bossStoreId, request.feedbackType)
     }
 
     private fun validateNotExistsFeedbackToday(storeId: String, userId: Long, date: LocalDate) {
         if (bossStoreFeedbackRepository.existsByStoreIdAndUserIdAndDate(storeId, userId, date)) {
             throw ConflictException("해당 날짜($date)에 유저($userId)는 해당 가게($storeId)에 이미 피드백을 추가하였습니다", ErrorCode.CONFLICT)
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun retrieveBossStoreFeedbacks(bossStoreId: String): Map<String, Long> {
+        BossStoreServiceUtils.validateExistsBossStore(bossStoreRepository, bossStoreId)
+        val counts = bossStoreFeedbackCounter.getAllCounts(bossStoreId) as MutableMap<String, Long>
+        for (feedbackType in BossStoreFeedbackType.values()) {
+            if (counts[feedbackType.name] == null) {
+                counts[feedbackType.name] = 0
+            }
+        }
+        return counts
     }
 
 }

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/dto/request/AddBossStoreFeedbackRequest.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/feedback/dto/request/AddBossStoreFeedbackRequest.kt
@@ -1,0 +1,20 @@
+package com.depromeet.threedollar.boss.api.service.feedback.dto.request
+
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedback
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedbackType
+import java.time.LocalDate
+
+data class AddBossStoreFeedbackRequest(
+    val feedbackType: BossStoreFeedbackType
+) {
+
+    fun toDocument(storeId: String, userId: Long, date: LocalDate): BossStoreFeedback {
+        return BossStoreFeedback(
+            storeId = storeId,
+            userId = userId,
+            feedbackType = feedbackType,
+            date = date
+        )
+    }
+
+}

--- a/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/store/BossStoreServiceUtils.kt
+++ b/threedollar-api-boss/src/main/kotlin/com/depromeet/threedollar/boss/api/service/store/BossStoreServiceUtils.kt
@@ -18,6 +18,12 @@ object BossStoreServiceUtils {
             ?: throw NotFoundException("사장님 (${bossId})이 운영중인 가게가 존재하지 않습니다", ErrorCode.NOTFOUND_BOSS_OWNED_STORE)
     }
 
+    fun validateExistsBossStore(bossStoreRepository: BossStoreRepository, bossStoreId: String) {
+        if (!bossStoreRepository.existsBossStoreById(bossStoreId = bossStoreId)) {
+            throw NotFoundException("해당하는 가게(${bossStoreId})는 존재하지 않습니다", ErrorCode.NOTFOUND_STORE)
+        }
+    }
+
     fun validateExistsBossStoreByBoss(bossStoreRepository: BossStoreRepository, bossStoreId: String, bossId: String) {
         if (!bossStoreRepository.existsBossStoreByIdAndBossId(bossStoreId = bossStoreId, bossId = bossId)) {
             throw NotFoundException("사장님($bossStoreId)이 운영중인 ($bossStoreId) 가게는 존재하지 않습니다", ErrorCode.NOTFOUND_STORE)

--- a/threedollar-common/src/main/java/com/depromeet/threedollar/common/exception/type/ErrorCode.java
+++ b/threedollar-common/src/main/java/com/depromeet/threedollar/common/exception/type/ErrorCode.java
@@ -66,7 +66,8 @@ public enum ErrorCode {
     CONFLICT_NICKNAME(HttpStatusCode.CONFLICT, OFF, "CF001", "이미 사용중인 닉네임입니다.\n다른 닉네임을 이용해주세요"),
     CONFLICT_USER(HttpStatusCode.CONFLICT, OFF, "CF002", "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요"),
     CONFLICT_DELETE_REQUEST_STORE(HttpStatusCode.CONFLICT, OFF, "CF003", "이미 해당하는 가게에 삭제요청 하였습니다."),
-    CONFLICT_VISIT_HISTORY(HttpStatusCode.CONFLICT, OFF, "CF004", "오늘 이미 방문 인증한 가게입니다.\n다음에 다시 인증해주세요"),
+    CONFLICT_VISIT_HISTORY(HttpStatusCode.CONFLICT, OFF, "CF004", "오늘 이미 방문 인증한 가게입니다.\n내일 다시 인증해주세요"),
+    CONFLICT_BOSS_STORE_FEEDBACK(HttpStatusCode.CONFLICT, OFF, "CF005", "오늘 이미 피드백을 추가한 가게입니다.\n내일 다시 인증해주세요"),
 
 
     // 415 Unsupported Media Type

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedback.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedback.kt
@@ -2,11 +2,13 @@ package com.depromeet.threedollar.document.boss.document.feedback
 
 import com.depromeet.threedollar.document.common.document.BaseDocument
 import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDate
 
 @Document("boss_store_feedback_v1")
 class BossStoreFeedback(
     val storeId: String,
-    val userId: String,
-    val feedbackType: BossStoreFeedbackType
+    val userId: Long,
+    val feedbackType: BossStoreFeedbackType,
+    val date: LocalDate
 ) : BaseDocument()
 

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedbackRepository.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedbackRepository.kt
@@ -1,5 +1,6 @@
 package com.depromeet.threedollar.document.boss.document.feedback
 
+import com.depromeet.threedollar.document.boss.document.feedback.repository.BossStoreFeedbackRepositoryCustom
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface BossStoreFeedbackRepository : MongoRepository<BossStoreFeedback, String>
+interface BossStoreFeedbackRepository : MongoRepository<BossStoreFeedback, String>, BossStoreFeedbackRepositoryCustom

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/repository/BossStoreFeedbackRepositoryCustom.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/repository/BossStoreFeedbackRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package com.depromeet.threedollar.document.boss.document.feedback.repository
+
+import java.time.LocalDate
+
+interface BossStoreFeedbackRepositoryCustom {
+
+    fun existsByStoreIdAndUserIdAndDate(storeId: String, userId: Long, date: LocalDate): Boolean
+
+}

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/repository/BossStoreFeedbackRepositoryCustomImpl.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/feedback/repository/BossStoreFeedbackRepositoryCustomImpl.kt
@@ -1,0 +1,21 @@
+package com.depromeet.threedollar.document.boss.document.feedback.repository
+
+import com.depromeet.threedollar.document.boss.document.feedback.BossStoreFeedback
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.isEqualTo
+import java.time.LocalDate
+
+class BossStoreFeedbackRepositoryCustomImpl(
+    private val mongoTemplate: MongoTemplate
+) : BossStoreFeedbackRepositoryCustom {
+
+    override fun existsByStoreIdAndUserIdAndDate(storeId: String, userId: Long, date: LocalDate): Boolean {
+        return mongoTemplate.exists(Query()
+            .addCriteria(BossStoreFeedback::storeId isEqualTo storeId)
+            .addCriteria(BossStoreFeedback::userId isEqualTo userId)
+            .addCriteria(BossStoreFeedback::date isEqualTo date), BossStoreFeedback::class.java
+        )
+    }
+
+}

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/store/repository/BossStoreRepositoryCustom.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/store/repository/BossStoreRepositoryCustom.kt
@@ -8,4 +8,6 @@ interface BossStoreRepositoryCustom {
 
     fun existsBossStoreByIdAndBossId(bossStoreId: String, bossId: String): Boolean
 
+    fun existsBossStoreById(bossStoreId: String): Boolean
+
 }

--- a/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/store/repository/BossStoreRepositoryCustomImpl.kt
+++ b/threedollar-document/src/main/kotlin/com/depromeet/threedollar/document/boss/document/store/repository/BossStoreRepositoryCustomImpl.kt
@@ -23,4 +23,10 @@ class BossStoreRepositoryCustomImpl(
         )
     }
 
+    override fun existsBossStoreById(bossStoreId: String): Boolean {
+        return mongoTemplate.exists(Query()
+            .addCriteria(BossStore::id isEqualTo bossStoreId), BossStore::class.java
+        )
+    }
+
 }

--- a/threedollar-document/src/testFixtures/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedbackCreator.kt
+++ b/threedollar-document/src/testFixtures/kotlin/com/depromeet/threedollar/document/boss/document/feedback/BossStoreFeedbackCreator.kt
@@ -1,0 +1,23 @@
+package com.depromeet.threedollar.document.boss.document.feedback
+
+import com.depromeet.threedollar.document.TestFixture
+import java.time.LocalDate
+
+@TestFixture
+object BossStoreFeedbackCreator {
+
+    fun create(
+        storeId: String,
+        userId: Long,
+        feedbackType: BossStoreFeedbackType,
+        date: LocalDate
+    ): BossStoreFeedback {
+        return BossStoreFeedback(
+            storeId = storeId,
+            userId = userId,
+            feedbackType = feedbackType,
+            date = date
+        )
+    }
+
+}

--- a/threedollar-external/src/main/java/com/depromeet/threedollar/external/client/slack/DummySlackWebhookApiClient.java
+++ b/threedollar-external/src/main/java/com/depromeet/threedollar/external/client/slack/DummySlackWebhookApiClient.java
@@ -14,7 +14,7 @@ public class DummySlackWebhookApiClient implements SlackWebhookApiClient {
 
     @Override
     public void postMessage(PostSlackMessageRequest request) {
-        log.info("Dummy Slack API를 호출합니다. {}", request.toString());
+
     }
 
 }


### PR DESCRIPTION
## 변경사항

- 사장님 가게에 피드백을 등록하는 API (차후 유저 서버로 옮겨야 함)
- 특정 사장님 가게에 등록된 전체 기간동안의 피드백 갯수를 조회하는 API

피드백에 대한 Raw 데이터는 몽고디비에서 관리하고, 가게 별 피드백 전체 갯수 정보는 레디스에 추가적으로 보관
